### PR TITLE
Adjust disabled state for buttons (dark-mode)

### DIFF
--- a/src/assets/styles/_defaults.scss
+++ b/src/assets/styles/_defaults.scss
@@ -52,6 +52,7 @@ $font-weight-bold: 600;
   --btn-info-active: #{darken(#6a8ca6, 5)};
   --btn-funding: #ea4aaa;
   --btn-funding-active: #{darken(#ea4aaa, 5)};
+  --btn-disabled: #ccc;
 
   --hint-bg: #e8c8bc;
   --hint-rgb: #{red(#e8c8bc), green(#e8c8bc), blue(#e8c8bc)};
@@ -104,6 +105,8 @@ html[data-color-scheme=dark] {
 
   --btn-info: #25455f;
   --btn-info-active: #253846;
+  --btn-disabled: #151517;
+  --opacity-disabled: 0.5;
 
   --hint-rgb: 57, 9, 20;
 

--- a/src/assets/styles/_forms.scss
+++ b/src/assets/styles/_forms.scss
@@ -210,9 +210,10 @@ select {
 
     &:disabled,
     &.disabled {
-        background-color: var(--border) !important;
-        border-color: var(--border) !important;
+        background-color: var(--btn-disabled) !important;
+        border-color: var(--btn-disabled) !important;
         cursor: not-allowed;
+        opacity: var(--opacity-disabled, 1);
     }
 
     &.disabled {


### PR DESCRIPTION
This PR adjusts the colors for the `button:disabled` state in dark mode.

*(Please mind that I've simulated the buttons quickly to show the changes)*

**Darkmode**
Before
![image](https://github.com/contao/package-list/assets/55794780/040624fb-5588-4279-87e8-9f0bce3c1898)

After
![image](https://github.com/contao/package-list/assets/55794780/137d4f0b-662b-47dd-83d1-867360052abb)


**Lightmode (no changes)**
Before
![image](https://github.com/contao/package-list/assets/55794780/96e71032-350a-483e-be75-159bf7596c66)

After
![image](https://github.com/contao/package-list/assets/55794780/f7c03426-1ca7-48ce-a9c9-dc73dfb5f413)
