### PR TITLE
Restyle scrollbar for tabs in the package detail view

### DIFF
--- a/src/components/fragments/PackageDetails.vue
+++ b/src/components/fragments/PackageDetails.vue
@@ -511,12 +511,13 @@
                 top: 0;
                 bottom: 1px;
                 width: 7px;
-                background: linear-gradient(-90deg, transparent 0, var(--popup-bg) 100%);
+                background: linear-gradient(-90deg, transparent 0, var(--popup-bg) 50%);
                 z-index: 1;
+                pointer-events: none;
             }
 
             &::after {
-                background: linear-gradient(90deg, transparent 0, var(--popup-bg) 100%);
+                background: linear-gradient(90deg, transparent 0, var(--popup-bg) 50%);
                 right: 0;
             }
         }

--- a/src/components/fragments/PackageDetails.vue
+++ b/src/components/fragments/PackageDetails.vue
@@ -47,45 +47,47 @@
                     </slot>
                 </div>
             </div>
-            <ul class="package-popup__tabs">
-                <details-tab
-                    show-empty
-                    :links="false"
-                    :active="tab === ''"
-                    @click="setTab('')"
-                >{{ $t('ui.package-details.tabDescription') }}</details-tab>
-                <details-tab
-                    highlight
-                    :links="metadata.features"
-                    :active="tab === 'features'"
-                    @click="setTab('features')"
-                    v-if="metadata.features"
-                >{{ $t('ui.package-details.tabFeatures') }}</details-tab>
-                <details-tab
-                    highlight
-                    :active="tab === 'suggest'"
-                    :links="metadata.suggest"
-                    @click="setTab('suggest')"
-                >{{ $t('ui.package-details.tabSuggest') }}</details-tab>
-                <details-tab
-                    show-empty
-                    :active="tab === 'require'"
-                    :links="metadata.require"
-                    @click="setTab('require')"
-                >{{ $t('ui.package-details.tabRequire') }}</details-tab>
-                <details-tab
-                    show-empty
-                    :active="tab === 'conflict'"
-                    :links="metadata.conflict"
-                    @click="setTab('conflict')"
-                >{{ $t('ui.package-details.tabConflict') }}</details-tab>
-                <details-tab
-                    :active="tab === 'dependents'"
-                    :links="dependents"
-                    @click="setTab('dependents')"
-                    v-if="dependents"
-                >{{ $t('ui.package-details.tabDependents') }}</details-tab>
-            </ul>
+            <div class="package-popup__tabs">
+                <ul class="package-popup__tabs-list">
+                    <details-tab
+                        show-empty
+                        :links="false"
+                        :active="tab === ''"
+                        @click="setTab('')"
+                    >{{ $t('ui.package-details.tabDescription') }}</details-tab>
+                    <details-tab
+                        highlight
+                        :links="metadata.features"
+                        :active="tab === 'features'"
+                        @click="setTab('features')"
+                        v-if="metadata.features"
+                    >{{ $t('ui.package-details.tabFeatures') }}</details-tab>
+                    <details-tab
+                        highlight
+                        :active="tab === 'suggest'"
+                        :links="metadata.suggest"
+                        @click="setTab('suggest')"
+                    >{{ $t('ui.package-details.tabSuggest') }}</details-tab>
+                    <details-tab
+                        show-empty
+                        :active="tab === 'require'"
+                        :links="metadata.require"
+                        @click="setTab('require')"
+                    >{{ $t('ui.package-details.tabRequire') }}</details-tab>
+                    <details-tab
+                        show-empty
+                        :active="tab === 'conflict'"
+                        :links="metadata.conflict"
+                        @click="setTab('conflict')"
+                    >{{ $t('ui.package-details.tabConflict') }}</details-tab>
+                    <details-tab
+                        :active="tab === 'dependents'"
+                        :links="dependents"
+                        @click="setTab('dependents')"
+                        v-if="dependents"
+                    >{{ $t('ui.package-details.tabDependents') }}</details-tab>
+                </ul>
+            </div>
             <details-content v-show="tab === ''">
                 <div class="package-popup__abandoned" v-if="metadata.abandoned">
                     <template v-if="metadata.abandoned === true">{{ $t('ui.package.abandonedText') }}</template>
@@ -498,16 +500,39 @@
         }
 
         &__tabs {
+            position: relative;
+            flex-grow: revert;
+
+            &::before,
+            &::after {
+                content: "";
+                display: block;
+                position: absolute;
+                top: 0;
+                bottom: 1px;
+                width: 7px;
+                background: linear-gradient(-90deg, transparent 0, var(--popup-bg) 100%);
+                z-index: 1;
+            }
+
+            &::after {
+                background: linear-gradient(90deg, transparent 0, var(--popup-bg) 100%);
+                right: 0;
+            }
+        }
+
+        &__tabs-list {
             flex-shrink: 0;
             flex-grow: 0;
-            position: relative;
             display: flex;
+            column-gap: 4px;
             height: 40px;
             min-width: 100%;
             overflow-x: auto;
+            scrollbar-width: none;
             overflow-y: hidden;
             margin: 0;
-            padding: 0 5px;
+            padding: 0 7px;
             list-style-type: none;
 
             &::after {
@@ -524,7 +549,6 @@
             position: relative;
             top: 1px;
             flex-grow: 1;
-            margin: 0 2px;
             padding: 0;
             height: 39px;
             line-height: 39px;


### PR DESCRIPTION
### Description

- fixes / prevents https://github.com/contao/contao-manager/issues/815

This approach is similar to the jump-targets in the current Contao 5.3 LTS with pseudo-elements with gradients indicating that scrolling is allowed.

> _Please mind that I am using a long word for the Description to simulate this change :)_

### More information on the changes

* `__tabs` have been renamed to `__tabs-list`, `__tabs` is needed for the pseudo elements

* the `flex-grow: revert` on `__tabs` is to keep the height of 40px (on mobile it would otherwise lead to a bug)

* I removed the `margin: 0 2px` from every `__tab` and added `column-gap` and raised the `padding` in the `__tabs_list`

* The removed `position: relative` on the `__tabs_list` is necessary for the pseudo-border to be aligned with the parent, rather than the scrolled content as it would never be able to stretch to the full width

### Screenshots

#### Before
![image](https://github.com/contao/package-list/assets/55794780/1a6a110b-c4d6-4459-bef7-d6e4abca5a6e)

#### After
![image](https://github.com/contao/package-list/assets/55794780/c0efcb1b-5ca1-4c9f-a838-92135d765098)
![image](https://github.com/contao/package-list/assets/55794780/159019b1-28ca-487d-b825-e3a6520cb0a2)
![image](https://github.com/contao/package-list/assets/55794780/03868ac8-7537-4643-a7b4-d524677c6c49)
![image](https://github.com/contao/package-list/assets/55794780/e93be16f-f06c-4471-9342-a909395dd1f3)
