### PR TITLE
Implement available contao-versions

### DIFF
--- a/src/assets/styles/_defaults.scss
+++ b/src/assets/styles/_defaults.scss
@@ -28,6 +28,8 @@ $font-weight-bold: 600;
   --shadow: #ccbfa2;
   --contao: #f47c00;
 
+  --badge-bg: var(--contao);
+
   --ad-shadow: #{0 1px 5px 1px rgba(0, 0, 0, 0.2)};
 
   --black: #000;
@@ -90,6 +92,8 @@ html[data-color-scheme=dark] {
   --highlight-color: #fff;
 
   --shadow: transparent;
+
+  --badge-bg: var(--border--light);
 
   --ad-shadow: none;
 

--- a/src/components/fragments/DiscoverPackage.vue
+++ b/src/components/fragments/DiscoverPackage.vue
@@ -4,7 +4,7 @@
         <package-logo class="discover-package__icon" :class="{ 'discover-package__icon--fallback': !data.logo }" :src="data.logo"/>
         <div class="discover-package__details">
             <div class="discover-package__headline-container">
-                <ul class="discover-package__versions" :title="$t('ui.package.contao_versions') + ' ' + data.contaoVersions" :class="{ 'discover-package__versions--fallback': !data.logo }">
+                <ul class="discover-package__versions" :title="`${$t('ui.package.contaoVersion')} ${data.contaoVersions.join(', ')}`" :class="{ 'discover-package__versions--fallback': !data.logo }" v-if="data.contaoVersions">
                     <li class="discover-package__version" v-for="(version, i) in data.contaoVersions" :key="i">{{ version }}</li>
                 </ul>
                 <h1 class="discover-package__headline" :class="{ 'discover-package__headline--fallback': !data.logo }" :title="data.name !== data.title ? data.name : ''">
@@ -151,7 +151,7 @@ export default {
             display: inline-flex;
             justify-content: center;
             padding: 3px 5px;
-            border-radius: 6px;
+            border-radius: 4px;
             line-height: 1;
             min-width: 40px;
             font-size: 13px;
@@ -266,7 +266,7 @@ export default {
 
             &__versions {
                 float: right;
-                margin: 0 0 0 16px;
+                margin: -3px 0 0 16px;
             }
 
             &__headline,

--- a/src/components/fragments/DiscoverPackage.vue
+++ b/src/components/fragments/DiscoverPackage.vue
@@ -3,12 +3,17 @@
         <div class="discover-package__abandoned" :title="abandonedText" v-if="data.abandoned">{{ $t('ui.package.abandoned') }}</div>
         <package-logo class="discover-package__icon" :class="{ 'discover-package__icon--fallback': !data.logo }" :src="data.logo"/>
         <div class="discover-package__details">
-            <h1 class="discover-package__headline" :class="{ 'discover-package__headline--fallback': !data.logo }" :title="data.name !== data.title ? data.name : ''">
-                <template v-for="(fragment, i) in title.split('%%')">
-                    <em :key="i" v-if="i % 2">{{ fragment }}</em>
-                    <template v-else>{{ fragment }}</template>
-                </template>
-            </h1>
+            <div class="discover-package__headline-container">
+                <ul class="discover-package__versions" :title="$t('ui.package.contao_versions') + ' ' + data.contaoVersions" :class="{ 'discover-package__versions--fallback': !data.logo }">
+                    <li class="discover-package__version" v-for="(version, i) in data.contaoVersions" :key="i">{{ version }}</li>
+                </ul>
+                <h1 class="discover-package__headline" :class="{ 'discover-package__headline--fallback': !data.logo }" :title="data.name !== data.title ? data.name : ''">
+                    <template v-for="(fragment, i) in title.split('%%')">
+                        <em :key="i" v-if="i % 2">{{ fragment }}</em>
+                        <template v-else>{{ fragment }}</template>
+                    </template>
+                </h1>
+            </div>
             <p class="discover-package__description" :class="{ 'discover-package__description--fallback': !data.logo }">
                 <template v-for="(fragment, i) in description.split('%%')">
                     <em :key="i" v-if="i % 2">{{ fragment }}</em>
@@ -133,6 +138,28 @@ export default {
             }
         }
 
+        &__versions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 5px;
+            list-style: none;
+            margin: 5px 0;
+            padding: 0;
+        }
+
+        &__version {
+            display: inline-flex;
+            justify-content: center;
+            padding: 3px 5px;
+            border-radius: 6px;
+            line-height: 1;
+            min-width: 40px;
+            font-size: 13px;
+            color: #fff;
+            background: var(--badge-bg);
+            pointer-events: none;
+        }
+
         &__description {
             display: -webkit-box;
             overflow: hidden;
@@ -196,6 +223,13 @@ export default {
             gap: 8px;
         }
 
+        @media (max-width: 599.98px) {
+            &__headline-container {
+                display: flex;
+                flex-direction: column-reverse;
+            }
+        }
+
         @include screen(600) {
             text-align: initial;
             display: flex;
@@ -228,6 +262,11 @@ export default {
                 min-height: 90px;
                 max-width: calc(100% - 130px);
                 flex: 1;
+            }
+
+            &__versions {
+                float: right;
+                margin: 0 0 0 16px;
             }
 
             &__headline,

--- a/src/components/fragments/PackageDetails.vue
+++ b/src/components/fragments/PackageDetails.vue
@@ -98,6 +98,12 @@
                 <package-funding class="package-popup__funding" :items="metadata.funding" v-if="metadata.funding"/>
                 <slot name="package-update"/>
                 <p v-if="metadata.latest"><strong>{{ $t('ui.package-details.latest') }}:</strong> {{ metadata.latest.version}} ({{ $t('ui.package-details.released') }} {{ metadata.latest.time | datimFormat('short', 'long') }})</p>
+                <div v-if="metadata.contaoVersions"><strong>{{ $t('ui.package.contao_versions') }} </strong>
+                    <template v-for="(fragment, i) in metadata.contaoVersions">
+                        <span :key="i" v-if="i === Object.values(metadata.contaoVersions).length - 1">{{ fragment }}</span>
+                        <template v-else>{{ fragment }}, </template>
+                    </template>
+                </div>
                 <p v-if="metadata.license"><strong>{{ $t('ui.package-details.license') }}:</strong> {{ license }}</p>
                 <p class="package-popup__description">{{ metadata.description }}</p>
             </details-content>
@@ -175,6 +181,7 @@
 
             authors: vm => (vm.metadata.authors && vm.metadata.authors.length) ? vm.metadata.authors.filter(a => !!a.name) : null,
             license: vm => vm.metadata.license ? (vm.metadata.license instanceof Array ? vm.metadata.license.join(', ') : vm.metadata.license) : '–',
+            contaoVersions: vm => vm.metadata.contaoVersions ? vm.metadata.contaoVersions : null,
         },
 
         methods: {

--- a/src/components/fragments/PackageDetails.vue
+++ b/src/components/fragments/PackageDetails.vue
@@ -97,13 +97,8 @@
                 </div>
                 <package-funding class="package-popup__funding" :items="metadata.funding" v-if="metadata.funding"/>
                 <slot name="package-update"/>
+                <p v-if="metadata.contaoVersions"><strong>{{ $t('ui.package-details.contaoVersions') }}:</strong> {{ metadata.contaoVersions.join(', ') }}</p>
                 <p v-if="metadata.latest"><strong>{{ $t('ui.package-details.latest') }}:</strong> {{ metadata.latest.version}} ({{ $t('ui.package-details.released') }} {{ metadata.latest.time | datimFormat('short', 'long') }})</p>
-                <div v-if="metadata.contaoVersions"><strong>{{ $t('ui.package.contao_versions') }} </strong>
-                    <template v-for="(fragment, i) in metadata.contaoVersions">
-                        <span :key="i" v-if="i === Object.values(metadata.contaoVersions).length - 1">{{ fragment }}</span>
-                        <template v-else>{{ fragment }}, </template>
-                    </template>
-                </div>
                 <p v-if="metadata.license"><strong>{{ $t('ui.package-details.license') }}:</strong> {{ license }}</p>
                 <p class="package-popup__description">{{ metadata.description }}</p>
             </details-content>
@@ -181,7 +176,7 @@
 
             authors: vm => (vm.metadata.authors && vm.metadata.authors.length) ? vm.metadata.authors.filter(a => !!a.name) : null,
             license: vm => vm.metadata.license ? (vm.metadata.license instanceof Array ? vm.metadata.license.join(', ') : vm.metadata.license) : '–',
-            contaoVersions: vm => vm.metadata.contaoVersions ? vm.metadata.contaoVersions : null,
+            contaoVersions: vm => vm.metadata.contaoVersions || null,
         },
 
         methods: {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -34,6 +34,7 @@
     "ui.package.abandoned": "abandoned",
     "ui.package.abandonedText": "This package is abandoned and no longer maintained.",
     "ui.package.abandonedReplace": "This package is abandoned and no longer maintained. The author suggests using the {replacement} package instead.",
+    "ui.package.contao_versions": "Available for following Contao versions:",
 
     "ui.package-details.previous": "Previous Extension Details",
     "ui.package-details.close": "Close Extension Details",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -34,7 +34,7 @@
     "ui.package.abandoned": "abandoned",
     "ui.package.abandonedText": "This package is abandoned and no longer maintained.",
     "ui.package.abandonedReplace": "This package is abandoned and no longer maintained. The author suggests using the {replacement} package instead.",
-    "ui.package.contao_versions": "Available for following Contao versions:",
+    "ui.package.contaoVersion": "Available for Contao",
 
     "ui.package-details.previous": "Previous Extension Details",
     "ui.package-details.close": "Close Extension Details",
@@ -50,6 +50,7 @@
     "ui.package-details.linkProvides": "provides",
     "ui.package-details.linkConflicts": "conflicts",
     "ui.package-details.funding": "Fund package maintenance!",
+    "ui.package-details.contaoVersions": "Supported Contao version(s)",
     "ui.package-details.latest": "Latest version",
     "ui.package-details.released": "released on",
     "ui.package-details.license": "License(s)",


### PR DESCRIPTION
## Description

As discussed with @aschempp in the contao-call (25.06.2024), we want to make sure that people can easily find out if they can install a package based on the current contao minor/major.

Thanks to @ausi's work (https://github.com/contao/package-metadata/pull/574, https://github.com/contao/package-metadata/pull/575, https://github.com/contao/package-metadata/pull/576) within package-metadata, the information are now possible to grab for the package-list (and when merged, also available in the contao-manager).

## Current preview

A current preview is available via https://sebastian.oveleon.com/package-list/

### Mobile
![image](https://github.com/user-attachments/assets/91e800c0-b60f-4407-bb04-7399377c53b6)
![image](https://github.com/user-attachments/assets/2f332478-2be4-4f3f-be24-1ae4eff491aa)

### Desktop
![image](https://github.com/user-attachments/assets/181880c6-5b28-468d-95dd-95eadb135f06)
![image](https://github.com/user-attachments/assets/ee0dd114-066c-4bfc-8d52-33c013d0fe7d)

### Package details
![image](https://github.com/user-attachments/assets/73f4005a-0850-489e-9a79-3d8950e8980f)

